### PR TITLE
[NO STORY] Cache test dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-stack-{{ checksum "package.yaml" }}
+            - v1-stack-{{ checksum "package.yaml" }}-{{ checksum "stack.yaml" }}
+            - v1-stack-{{ checksum "package.yaml" }}-
             - v1-stack-
 
       - run: stack setup
@@ -22,7 +23,7 @@ jobs:
       - run: stack build --test --no-run-tests
 
       - save_cache:
-          key: v1-stack-{{ checksum "package.yaml" }}
+          key: v1-stack-{{ checksum "package.yaml" }}-{{ checksum "stack.yaml" }}
           paths:
             - .stack-work
             - /root/.stack


### PR DESCRIPTION
# Facts
- Circle CI cache is immutable

# Problem
- First v1-stack-{{ checksum "package.yaml" }} cache was created without testing dependencies, therefore, test dependencies are installed always between builds.
- v1-stack-{{ checksum "package.yaml" }}  is not good enough to create an inmutable cache since sometimes dependencies could change without modifying the package.yaml file like here https://github.com/stackbuilders/gig-economy/pull/23/files#diff-fafd0cdcd559a7b124cc61c29413fb54R57

# Solution
- Create a cache key composed by package.yaml and stack.yaml checksums, following Circle CI Haskell tutorial https://circleci.com/docs/2.0/language-haskell/

![image](https://user-images.githubusercontent.com/2049686/55841650-9ed8b380-5af5-11e9-8638-1e8c1a955899.png)

Fully cached build now take around 1 minute
